### PR TITLE
Use "Web user agent" in title and intro

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Title: Web User Agents
-Shortname: user-agents
+Shortname: web-user-agents
 Level: none
 Status: NOTE-ED
 Group: tag

--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: User Agents
+Title: Web User Agents
 Shortname: user-agents
 Level: none
 Status: NOTE-ED
@@ -21,7 +21,7 @@ Abstract: Web user agents include both web browsers and other intermediaries
 
 </pre>
 
-# What is a user agent # {#what}
+# What is a web user agent # {#what}
 
 A <dfn lt="user agent|web user agent" export>web user agent</dfn> is
 any software entity that interacts with websites outside the entity itself,

--- a/index.bs
+++ b/index.bs
@@ -27,7 +27,7 @@ A <dfn lt="user agent|web user agent" export>web user agent</dfn> is
 any software entity that interacts with websites outside the entity itself,
 on behalf of its user,
 including just to display the content of websites.
-In web specifications,
+In web specifications and the rest of this document,
 web user agents are usually referred to as just "[=user agents=]",
 but there are other kinds of user agents in other domains,
 for example "mail user agents" in the context of email.


### PR DESCRIPTION
Since this is specifically about Web user agents, the title would benefit from reflecting it


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/user-agents/pull/10.html" title="Last updated on Mar 15, 2025, 5:46 PM UTC (79204d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/10/de9852f...dontcallmedom:79204d4.html" title="Last updated on Mar 15, 2025, 5:46 PM UTC (79204d4)">Diff</a>