### PR TITLE
Remove "permanent" from the kind of disallowed changes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -80,7 +80,7 @@ and embodied in the various standards that user agents implement.
 
 [[design-principles#safe-to-browse|It should be safe to visit a web page.]]
 That is, simply visiting a page must not allow
-the page to make permanent changes to the user's computer or environment
+the page to make changes to the user's computer or environment
 (for example by installing malware),
 and simply visiting should reveal
 as little information as practical about the user to the page,


### PR DESCRIPTION
I'd been thinking that visiting a web page intrinsically makes changes to a computer's RAM, so we couldn't ban _all_ changes, but I think #9 is right that this is too pedantic, and it's more useful to just make the shorter statement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#protection
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/user-agents/pull/16.html#protection" title="Last updated on Apr 16, 2025, 11:57 PM UTC (12efc28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/16/5765569...jyasskin:12efc28.html" title="Last updated on Apr 16, 2025, 11:57 PM UTC (12efc28)">Diff</a>