### PR TITLE
Add examples to the duty of protection.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -98,6 +98,52 @@ user agents should strive to prevent pages from tricking their users
 and should help their users notice
 when they might be giving the page more power than they intended.
 
+<div class="example" id="example-protection-exploits" heading="Attacks">
+
+When a person visits a website,
+any malicious code on that site
+is expected to be unable to escape the user agent to modify the person's computer,
+or even to read information stored inside other [=origins=].
+User agents currently satisfy their duty of protection by
+separating different parts of their implementation
+into different sandboxed processes,
+using memory-safe languages for increasing parts of their implementations,
+and employing active security teams to find and respond to vulnerabilities.
+Over time, user agents are expected to systematically improve their defenses
+to keep up with new kinds of attacks.
+
+User agents are also expected
+to use systems like [Safe Browsing](https://developers.google.com/safe-browsing/)
+to notify their users
+when a website is likely to be trying to take advantage of them.
+
+</div>
+
+<div class="example" id="example-protection-tracking" heading="Tracking">
+
+If a person visits a series of unrelated websites,
+it is practical to avoid sending a common identifying cookie
+to iframes embedded on all of those sites.
+A browser that does send such a cookie is failing in its duty of protection.
+However, it is not currently practical
+to avoid revealing the person's computer's stable IP address,
+so a browser that reveals this IP address isn't failing in its duties.
+
+</div>
+
+<div class="example" id="example-protection-local-files" heading="Local Files">
+
+User agents are expected
+to prevent web pages from discovering, reading, or writing local files
+unless their user specifically opens or selects a file
+to expose to a particular page.
+This motivates behaviors like
+* giving each `file:` URL its own [=url/origin=],
+* removing path components from
+    <a element-state for="input" lt="File Upload">`<input type=file>`</a> uploads, and
+* restricting which local fonts can be used in <a at-rule>@font-face</a> rules.
+
+</div>
 
 ## Honesty ## {#honesty}
 

--- a/index.bs
+++ b/index.bs
@@ -110,11 +110,6 @@ and employing active security teams to find and respond to vulnerabilities.
 Over time, user agents are expected to systematically improve their defenses
 to keep up with new kinds of attacks.
 
-User agents are also expected
-to use systems like [Safe Browsing](https://developers.google.com/safe-browsing/)
-to notify their users
-when a website is likely to be trying to take advantage of them.
-
 </div>
 
 <div class="example" id="example-protection-tracking" heading="Tracking">

--- a/index.bs
+++ b/index.bs
@@ -80,8 +80,7 @@ and embodied in the various standards that user agents implement.
 
 [[design-principles#safe-to-browse|It should be safe to visit a web page.]]
 That is, simply visiting a page must not allow
-the page to make changes to the user's computer or environment
-(for example by installing malware),
+the page to make changes to the user's computer or environment,
 and simply visiting should reveal
 as little information as practical about the user to the page,
 to the user's environment,
@@ -91,8 +90,7 @@ Users can [[privacy-principles#dfn-opt-in|opt into]]
 sharing more information with a page they visit,
 for example by entering or auto-filling data into form fields,
 or granting permissions to the page.
-Users can also allow the page to make changes to their environment,
-for example by installing native programs that the page offers.
+Users can also allow the page to make changes to their environment.
 Even in these cases,
 user agents should strive to prevent pages from tricking their users
 and should help their users notice
@@ -142,6 +140,17 @@ This motivates behaviors like
 * removing path components from
     <a element-state for="input" lt="File Upload">`<input type=file>`</a> uploads, and
 * restricting which local fonts can be used in <a at-rule>@font-face</a> rules.
+
+User agents are not expected
+to entirely prevent users from letting web pages read or write local files.
+As mentioned,
+<a element-state for="input" lt="File Upload">`<input type=file>`</a>
+allows uploading file contents,
+and user agents allow people to download files from the web,
+including dangerous executables.
+Smoother experiences like the [[file-system-access inline]] API
+also don't violate any duties,
+as long as users can [[design-principles#consent|meaningfully consent]].
 
 </div>
 


### PR DESCRIPTION
I'm not sure that these are the right set of examples or that any of them have the right content, but I think they roughly cover the content of #9.

There's an obvious question of why I prefer longer examples over incorporating their text into the main explanation of the duty. I think separating the example makes it easier for people to skim the duty itself, and then only read the example if they're looking for more detail. It also gives us space to be more precise about what makes different parts of the examples  fit or violate the duties, which again improves the chance that someone reading quickly will get the right idea.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#protection
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/user-agents/pull/17.html#protection" title="Last updated on Apr 23, 2025, 11:39 PM UTC (78f9aa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/17/ebf207f...jyasskin:78f9aa0.html" title="Last updated on Apr 23, 2025, 11:39 PM UTC (78f9aa0)">Diff</a>