### PR TITLE
Don't export "web user agent".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -33,7 +33,8 @@ This document is intended for:
 
 # What is a web user agent # {#what}
 
-A <dfn lt="user agent|web user agent" export>web user agent</dfn> is
+<!-- TODO: Export this once it can replace the Infra definition. -->
+A <dfn lt="user agent|web user agent" noexport>web user agent</dfn> is
 any software entity that interacts with websites outside the entity itself,
 on behalf of its user,
 including simply rendering the content of websites.


### PR DESCRIPTION
I'm belatedly acting on the agreement in https://github.com/w3ctag/meetings/blob/gh-pages/2025/09-Hong-Kong/09-17-minutes.md#agreement-to-publish-it-as-a-draft-note-and-echidna-it that we can publish this as a Draft Note once it doesn't export "user agent".

Once this is merged, @ylafon can manually publish the first version and get us an Echidna token to autopublish in the future.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/30.html" title="Last updated on Oct 29, 2025, 4:23 AM UTC (c98c9bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/30/bacfcf3...c98c9bd.html" title="Last updated on Oct 29, 2025, 4:23 AM UTC (c98c9bd)">Diff</a>