### PR TITLE
Fix the reference to the new user-intent design principle.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -124,7 +124,7 @@ This motivates behaviors like:
 However, users can still choose to share files,
 e.g., via uploads or downloads.
 APIs like [[file-system-access inline]] don’t violate this duty,
-provided users can [[design-principles#consent|meaningfully consent]].
+provided users have the tools to [[design-principles#user-decisions|make good decisions]].
 
 </div>
 


### PR DESCRIPTION
The old reference, https://www.w3.org/TR/design-principles/#consent, still exists (so no need to fix the design-principles), but because the section was rewritten, it doesn't quite support the old phrasing. Because we used the semantic section reference, Bikeshed [errored](https://github.com/w3ctag/user-agents/actions/runs/18896810286/job/53936018234) after the design-principles ID was changed, which revealed the need to rephrase this spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#example-protection-local-files
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/32.html" title="Last updated on Oct 29, 2025, 4:21 AM UTC (1706a61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/32/698bc20...1706a61.html" title="Last updated on Oct 29, 2025, 4:21 AM UTC (1706a61)">Diff</a>