### PR TITLE
fix 'should' appearing in example (only case flagged)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -189,9 +189,9 @@ provided users have the tools to [[design-principles#user-decisions|make good de
 
 <div class="example" id="example-avoid-risky-pages" heading="Risky Pages">
 
-User agents should attempt to identify pages that attack their visitors.
+User agents are expected to attempt to identify pages that attack their visitors.
 When a user starts visiting such a page, 
-the user agent should attempt to prevent the harm,
+the user agent might attempt to prevent the harm,
 for example by blocking the access or warning the user.
 
 </div>


### PR DESCRIPTION
Bikeshed flags the use of should here because it uses 'should' in an example, which is usually a non-normative place and _generally_ a mistake.  We can also choose to ignore it since the document itself isn't exactly a spec, but it did seem to be the only example that was flagged, and it did feel a little off to me, so maybe the rephrasing is as good.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/51.html" title="Last updated on Jul 17, 2026, 5:15 PM UTC (7399a51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/51/0f901f9...7399a51.html" title="Last updated on Jul 17, 2026, 5:15 PM UTC (7399a51)">Diff</a>