### PR TITLE
Use declarative duty language instead of terms overlap with RFC requirement levels

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Abstract: Web user agents include both web browsers and other intermediaries
     Each user agent serves its user,
     not any of the other constituencies.
     A user agent owes its user various duties,
-    which should be established through collective discussions
+    which are established through collective discussions
     and embodied in the various standards that user agents implement.
 
 </pre>
@@ -94,18 +94,18 @@ which browse content from outside the user agent itself,
 need to follow the [=user agent duties=].
 Parts that are clearly only showing the application's own content
 can act on their own behalf,
-but the application should still
-give its users clear expectations about
-what behavior they should expect from different parts of the application.
+but the application still
+gives its users clear expectations about
+what behavior to expect from different parts of the application.
 If the distinction between internal and external content is too small—for example
 if the application doesn't show an address bar
 or another indicator of content origin
 when browsing external content—then
-the application should also follow the [=user agent duties=]
+the application is expected to follow the [=user agent duties=]
 when showing its own content.
 
-Similarly a library that implements the web platform
-may or may not be a full [=user agent=].
+Similarly, whether a library that implements the web platform
+is a full [=user agent=] depends on what it does.
 Some, like [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller)
 and [Android Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs)
 take on the responsibility of implementing the [=user agent duties=]
@@ -137,29 +137,29 @@ Each user agent serves its user ([[!RFC8890 inline]]),
 not any of the other constituencies.
 A user agent owes its user various
 <dfn lt="user agent duties|UA duties">duties</dfn>,
-which should be established through collective discussions
+which are established through collective discussions
 and embodied in the various standards that user agents implement.
 
 
 ## Protection ## {#protection}
 
 [[design-principles#safe-to-browse|It should be safe to visit a web page.]]
-Visiting a page must not by itself
+Visiting a page does not by itself
 let the page change the user's computer or environment,
 such as by installing software or accessing hardware.
 
 Any data revealed to sites or other observers
-should be aligned with the user's preferences
-and follow the principle of [[design-principles#data-minimization|data minimization]].
-In particular, user agents must act to
+aligns with the user's preferences
+and follows the principle of [[design-principles#data-minimization|data minimization]].
+In particular, user agents act to
 limit the potential for sites to track user activity [[unsanctioned-tracking]].
 
-Users may [choose to share more information](https://www.w3.org/TR/privacy-principles/#dfn-opt-in),
+Users can [choose to share more information](https://www.w3.org/TR/privacy-principles/#dfn-opt-in),
 such as by filling out forms or granting permissions.
-Even then, user agents must help users avoid deception and
+Even then, user agents help users avoid deception and
 clearly signal when a page attempts to gain elevated access.
 
-If a page requests multiple permissions at once, it must be initiated by 
+If a page requests multiple permissions at once, it is initiated by
 user activation and the user agent needs to ensure both that the user can 
 grant a subset of the requested permissions, and that they are aware of 
 the full set that they are granting.
@@ -215,11 +215,11 @@ for example by blocking the access or warning the user.
 
 ## Honesty ## {#honesty}
 
-A user agent must mediate between the Web and its user,
-explaining what is happening in a form the user can understand. 
-When the user agent performs actions automatically or on behalf of the user, it must clearly communicate those actions and their consequences.
+A user agent mediates between the Web and its user,
+explaining what is happening in a form the user can understand.
+When the user agent performs actions automatically or on behalf of the user, it clearly communicates those actions and their consequences.
 
-A user agent may use multiple approaches for explanations, including
+A user agent can use multiple approaches for explanations, including
 text, permission prompts, indicators, previews, and other interface elements.
 Consider the placement of these elements and whether anything needs emphasis.
 
@@ -230,19 +230,19 @@ to some user agents explicitly including the text "not secure" in the URL bar.
 Specifications, like the [[mediacapture-streams inline]], include
 [[mediacapture-streams#privacy-indicator-requirements|Privacy Indicator Requirements]]
 that require user agents to explain some specific kinds of website behavior,
-but user agents should also use the same techniques when users need to know
+but user agents are expected to use the same techniques when users need to know
 about other behavior, even if a specification doesn't specifically call out that behavior.
 
 An honest user agent actively works to present the truth to its user.
 It doesn't just avoid lies.
 Its explanations
-should clearly represent the current state and likely consequences,
+clearly represent the current state and likely consequences,
 avoid euphemism or ambiguity,
 and make it obvious when sensitive activity is occurring.
 
-The user agent should choose when and how often to show these explanations,
+The user agent chooses when and how often to show these explanations,
 so explanations arrive when helpful and inform rather than distract.
-The user agent should ensure the user can control if and when they make a decision.
+The user agent ensures the user can control if and when they make a decision.
 
 For example, if a website is using a long-lived permission like geolocation or audio recording, 
 the user agent can explain what's happening by showing an indicator icon in the URL bar.
@@ -258,7 +258,7 @@ agent needs to clearly communicate where there are tradeoffs.
 
 ## Loyalty ## {#loyalty}
 
-A user agent must serve its user's interests
+A user agent serves its user's interests
 over its implementer's interests
 and over the interests of any other party.
 
@@ -270,8 +270,8 @@ A user agent can also help its user
 make a credible commitment to a page in order to get that page's services,
 and it's not disloyal to maintain that commitment after getting the services.
 
-A user agent must not obstruct its users from switching to another user agent.
-For example, it must not block access to, export, or store user data in ways that prevent portability.
+A user agent does not obstruct its users from switching to another user agent.
+For example, it does not block access to, export, or store user data in ways that prevent portability.
 This includes identity information, bookmarks, history, passwords, and credentials such as passkeys.
 If the user agent relies on the underlying <abbr title="Operating System">OS</abbr> to store credentials,
 there needs to be a way for users to allow other user agents to access those credentials.


### PR DESCRIPTION
Closes https://github.com/w3ctag/user-agents/issues/55

Bonus: This helps to ensure that the document is not using any requirement level language as commonly use in Rec/Note tracks. So, working towards text that doesn't include "normative" content.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/user-agents/pull/56.html" title="Last updated on Aug 10, 2026, 11:51 AM UTC (64ee26d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/56/f205b87...csarven:64ee26d.html" title="Last updated on Aug 10, 2026, 11:51 AM UTC (64ee26d)">Diff</a>