### PR TITLE
Fix broken RFC 8890 link and three grammar nits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -33,7 +33,7 @@ but a variety of other software plays the same role.
 The word "agent" is not incidental:
 A user agent works for its user,
 and when the user's interests conflict with another party's,
-it <a href="https://www.rfc-editor.org/info/rfc8890/">serves the user first</a>.
+it [[RFC8890|serves the user first]].
 
 This document describes what makes software a "user agent",
 and the duties a user agent owes its user:

--- a/index.bs
+++ b/index.bs
@@ -33,9 +33,9 @@ but a variety of other software plays the same role.
 The word "agent" is not incidental:
 A user agent works for its user,
 and when the user's interests conflict with another party's,
-it <a href="RFC8890">serves the user first</a>.
+it <a href="https://www.rfc-editor.org/info/rfc8890/">serves the user first</a>.
 
-This document describes what classifies software a "user agent",
+This document describes what makes software a "user agent",
 and the duties a user agent owes its user:
 protection, honesty, and loyalty.
 Rather than standing alone as requirements,
@@ -129,7 +129,7 @@ if it, or any part of it, acts as a [=user agent=].
 This can be straightforward if the application only browses external content through a [=user agent=] library.
 Developers need to take extra care
 to follow the [=user agent duties=]
-when using a non-[=user agent=] WebView to implement an in-app browser .
+when using a non-[=user agent=] WebView to implement an in-app browser.
 
 # Duties of user agents # {#duties}
 
@@ -265,7 +265,7 @@ the user agent can explain what's happening by showing an indicator icon in the 
 
 <div class="example" id="example-honesty-defaults" heading="Clear Communication">
 
-A user agent which convinces users to provide account information to the browser
+A user agent that convinces users to provide account information to the browser
 (and not a specific site), but then quietly defaults to using that information for
 other purposes like tracking or ad targeting is not acting honestly.  A user
 agent needs to clearly communicate where there are tradeoffs.


### PR DESCRIPTION
Fixes the RFC 8890 link in the introduction, which was a relative href and 404'd. Also three grammar nits: "classifies software a", a stray space before a period, and "which" to "that" in a restrictive clause.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/62.html" title="Last updated on Sep 7, 2026, 11:00 PM UTC (a095753)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/62/6e62f2b...a095753.html" title="Last updated on Sep 7, 2026, 11:00 PM UTC (a095753)">Diff</a>