### PR TITLE
Scope the arbitrary-content claim to the public web

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -68,7 +68,8 @@ if there's a chance of confusion.
 A person can use many different user agents in their day-to-day life.
 
 The most common type of web user agent is the web browser —
-including in-app browsers that can follow cross-site links ([[evergreen-web#updates|any product that can load arbitrary content is a web browser]]).
+including in-app browsers that can follow cross-site links.
+[[evergreen-web#updates|A product that can load arbitrary content from the public web is a browser]].
 However, user agents also include other tools like
 search engines, voice-driven assistants, and generative AI systems
 that present snippets or summaries of website content,


### PR DESCRIPTION
The parenthetical read as a universal test, and the next sentence contradicts it. Search engines and generative AI systems load arbitrary content, so the parenthetical made them browsers one sentence after the document says they are other kinds of user agent.

It also dropped the scoping from the finding it cites. The evergreen Web says vendors must decide whether their products can browse the public web, then that products which can load arbitrary content are browsers, then carves out closed systems that never reach the public web. This restores "from the public web" and moves the claim out of brackets.

This does not fully settle the conflict, since a crawler also loads arbitrary content from the public web. Filing the smaller fix and leaving the wider question of whether a search engine is a user agent for separate discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/63.html" title="Last updated on Sep 7, 2026, 10:46 PM UTC (4d20753)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/63/f62f967...4d20753.html" title="Last updated on Sep 7, 2026, 10:46 PM UTC (4d20753)">Diff</a>