### PR TITLE
Describe features rather than whole specifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -78,9 +78,11 @@ or perform automated actions on the user’s behalf.
 User agent behavior is not completely defined by web standards
 or even by technical specifications in general.
 In particular,
-user agents choose which specifications to implement in order to best serve their users,
-and they implement proprietary user interfaces and other behavior
-around the specifications they do implement.
+user agents choose which features to implement,
+and how much of each to expose,
+in order to best serve their users.
+They also build user interfaces and other behavior
+that no specification describes.
 
 ## User agents as software components ## {#ua-as-software}
 


### PR DESCRIPTION
Nobody ships a whole specification. Engines ship features, parts of features, behind flags, on some platforms first, over several releases. "Which specifications to implement" does not describe what happens, and it misses that a browser can implement a feature and still not expose it.

The second half said user agents implement behavior "around the specifications". Around can mean built next to, or it can mean worked around, and the second reading says a user agent may deviate from what a specification requires. "That no specification describes" keeps only the first meaning.

The actor stays as the user agent on purpose. The document treats the user agent as the one acting in fifteen other places, and the loyalty section deliberately separates a user agent from its implementer, so naming vendors here would work against that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/64.html" title="Last updated on Sep 8, 2026, 12:01 AM UTC (3514f5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/64/6e62f2b...3514f5a.html" title="Last updated on Sep 8, 2026, 12:01 AM UTC (3514f5a)">Diff</a>