### PR TITLE
Drop the user activation claim from the multiple permissions example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -161,10 +161,10 @@ clearly signal when a page attempts to gain elevated access.
 
 <div class="example" id="example-protection-multiple-permissions" heading="Multiple Permissions">
 
-If a page requests multiple permissions at once, it is initiated by
-user activation and the user agent needs to ensure both that the user can
-grant a subset of the requested permissions, and that they are aware of
-the full set that they are granting.
+When a page asks for several permissions,
+the user agent needs to ensure
+that the user can grant a subset of the requested permissions
+and that the user is aware of the full set they're granting.
 
 </div>
 


### PR DESCRIPTION
The example said a request for several permissions "is initiated by user activation". That reads as a statement of fact about the web, and it is not one. Screen capture does require transient activation, but Geolocation and Notifications never mention it.

It was not written as a statement of fact. It arrived in #43 as "it must be initiated by user activation", a requirement. The sweep in #56 replaced normative keywords with declarative language across the whole document, removing 22 of them over 26 changed lines, and that turned this particular must into an is.

This restores the wording Jeffrey suggested in the #43 review thread, with a short lead-in so it stands as a sentence. It keeps the point, which is that the user can grant some permissions and not others, and can see the full set being asked for.

Worth noting for whoever picks this up next: Media Capture already asks for something close by. It says that if a script calls getUserMedia() several times before reaching a stable state, "the permission dialogs should be merged, so that the user can give permission" with the full picture in view. That may be the better thing for this example to point at.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/pull/65.html" title="Last updated on Sep 8, 2026, 12:33 AM UTC (a7b13ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/user-agents/65/6e62f2b...a7b13ba.html" title="Last updated on Sep 8, 2026, 12:33 AM UTC (a7b13ba)">Diff</a>